### PR TITLE
Adds test for svg text, updates deps to not rely on global installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
   ],
   "devDependencies": {
     "browserify": "^11.2.0",
+    "chai": "^3.3.0",
     "karma": "^0.13.10",
     "karma-browserify": "^4.4.0",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.1"
+    "karma-phantomjs-launcher": "^0.2.1",
+    "mocha": "^2.3.3",
+    "phantomjs": "^1.9.18"
   },
   "scripts": {
     "build": "browserify src/select.js -s select -o dist/select.js",

--- a/test/select.js
+++ b/test/select.js
@@ -45,7 +45,7 @@ describe('select non-editable element with no children', function() {
     });
 });
 
-describe('select non-editable element with children nodes', function() {
+describe('select non-editable element with child node', function() {
     before(function() {
         global.li = document.createElement('li');
         global.li.textContent = 'lorem ipsum';
@@ -63,5 +63,31 @@ describe('select non-editable element with children nodes', function() {
     it('should return the selected text', function() {
         var result = select(global.ul);
         assert.equal(result, global.ul.textContent);
+    });
+});
+
+describe('select non-editable svg element w/ multiple text children', function() {
+    before(function() {
+        global.text1 = document.createElement('text');
+        global.text1.textContent = 'lorem ipsum';
+
+        global.text2 = document.createElement('text');
+        global.text2.textContent = 'dolor zet';
+
+        global.svg = document.createElement('svg');
+        global.svg.appendChild(global.text1);
+        global.svg.appendChild(global.text2);
+
+        document.body.appendChild(global.svg);
+    });
+
+    after(function() {
+        document.body.innerHTML = '';
+    });
+
+    it('should return the selected text', function() {
+        var result = select(global.svg);
+        assert.equal(result, global.text1.textContent +
+                             global.text2.textContent);
     });
 });


### PR DESCRIPTION
> As we can expect selection to work on anything that has a selectable
> text as part of the DOM (sorry canvas), svg could be handled as well
> as demonstrated by the tests. This commit makes this explicit.
> 
> Peer dependencies are explicitly added to `package.json` to not rely
> on global dependencies.
> -- **commit msg**

Didn't know about `Range` and `Selection` and was curious to see whether it'd work with SVG. Pretty cool! What do you think about including these tests as well?

:octopus: ,
