### PR TITLE
Make sure element is focused after selection

### DIFF
--- a/dist/select.js
+++ b/dist/select.js
@@ -14,6 +14,7 @@ function select(element) {
         range.selectNodeContents(element);
         selection.removeAllRanges();
         selection.addRange(range);
+        element.focus();
 
         selectedText = selection.toString();
     }

--- a/src/select.js
+++ b/src/select.js
@@ -13,6 +13,7 @@ function select(element) {
         range.selectNodeContents(element);
         selection.removeAllRanges();
         selection.addRange(range);
+        element.focus();
 
         selectedText = selection.toString();
     }


### PR DESCRIPTION
When selecting text it's not always guaranteed that the selection will be in focus. This is useful when using it alongside things like contenteditable so that you can start typing immediately.
