### PR TITLE
Add text selection support for inputs and textareas on iOS

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -2,7 +2,8 @@ function select(element) {
     var selectedText;
 
     if (element.nodeName === 'INPUT' || element.nodeName === 'TEXTAREA') {
-        element.select();
+        element.focus();
+        element.setSelectionRange(0, element.value.length);
 
         selectedText = element.value;
     }


### PR DESCRIPTION
It works on iOS Safari. It does work with multiple elements being selected in Firefox.
The idea is taken from https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select
